### PR TITLE
Add migration for cached row timestamps

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -17,6 +17,7 @@ Paths:
 
 Implementation notes:
 - `Row.created_at` captures the cache insertion second for each batch of inserted rows; `/rows?since=` comparisons currently use this timestamp as a proxy for freshness.
+- `init_db()` now runs a lightweight SQLite migration to add and backfill the `created_at` column on legacy cache databases so upgrades do not require manual rebuilds.
 - `query_rows` filters substring matches by casting the JSON payload to text and applying a `LOWER(...) LIKE %query%` check. SQLite handles this via its `TEXT` representation; if we move to a database without JSON casting support we may need a dedicated search strategy.
 - Future enhancement: persist upstream Sheet update timestamps or per-row hashes to make `since` filtering reflect actual Sheet edits rather than cache time.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Open http://127.0.0.1:8000/docs
 - Environment variables can be loaded from `.env`.
 - To install dev tooling without editable mode: `pip install -e ".[dev]"` after activating a Python 3.11 virtualenv.
 - Linting is configured with Ruff (see `pyproject.toml`).
+- `init_db()` automatically backfills the cached rows table with a `created_at` column if a legacy database is missing it, so `/rows?since=` continues working after upgrades without manual intervention.
 
 ### Filtering and projection
 - `GET /rows?q=alice` → case-insensitive search across the JSON payload of each cached row.


### PR DESCRIPTION
## Summary
- add a lightweight SQLite migration in init_db to backfill the cached row created_at column when missing
- document the automatic created_at backfill behaviour in the README and HANDOFF notes

## Testing
- pytest -q *(fails: missing optional httpx dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d672f7a670833085356eaf2c10d1b1