### PR TITLE
Ensure request IDs persist on error responses

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -23,7 +23,7 @@ Implementation notes:
 - `Row.created_at` captures the cache insertion second for each batch of inserted rows; `/rows?since=` comparisons currently use this timestamp as a proxy for freshness.
 - `init_db()` now runs a lightweight SQLite migration to add and backfill the `created_at` column on legacy cache databases so upgrades do not require manual rebuilds.
 - `query_rows` filters substring matches by casting the JSON payload to text and applying a `LOWER(...) LIKE %query%` check. SQLite handles this via its `TEXT` representation; if we move to a database without JSON casting support we may need a dedicated search strategy.
-- Access logging prints JSON objects with fields: `ts`, `level`, `msg`, `request_id`, `method`, `path`, `query`, `status`, `duration_ms`, `client_ip`, optional `error`, and redacted header echoes. The middleware always attaches an `X-Request-ID` response header.
+- Access logging prints JSON objects with fields: `ts`, `level`, `msg`, `request_id`, `method`, `path`, `query`, `status`, `duration_ms`, `client_ip`, optional `error`, and redacted header echoes. The middleware always attaches an `X-Request-ID` response header, even when a route raises and returns a `500` from the server error handler.
 - Prometheus metrics include `sb_requests_total{method,path,status}`, `sb_request_latency_seconds{method,path}`, and `sb_errors_total{path}`. `/metrics` returns the standard text exposition format.
 - Token bucket rate limiting is disabled by default; enable by toggling `RATE_LIMIT_ENABLED` and tuning `RATE_LIMIT_RPS` + `RATE_LIMIT_BURST`. Buckets are keyed by client IP.
 - Future enhancement: persist upstream Sheet update timestamps or per-row hashes to make `since` filtering reflect actual Sheet edits rather than cache time.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Open http://127.0.0.1:8000/docs
 - `init_db()` automatically backfills the cached rows table with a `created_at` column if a legacy database is missing it, so `/rows?since=` continues working after upgrades without manual intervention.
 
 ## Logging, request IDs, metrics, and rate limit
-- Structured JSON logs now stream to stdout for every request via `AccessLogMiddleware`. Each entry includes latency, status, method, path, a redacted subset of headers, and a `request_id` field that echoes/sets the `X-Request-ID` header on responses.
+- Structured JSON logs now stream to stdout for every request via `AccessLogMiddleware`. Each entry includes latency, status, method, path, a redacted subset of headers, and a `request_id` field that echoes/sets the `X-Request-ID` header on responses, including `500` errors raised by routes.
 - A Prometheus endpoint lives at `GET /metrics` and exports `sb_requests_total`, `sb_request_latency_seconds`, and `sb_errors_total` sourced from in-process counters and histograms.
 - Enable per-IP throttling by setting `RATE_LIMIT_ENABLED=1`. Tune the token bucket with `RATE_LIMIT_RPS` (refill rate) and `RATE_LIMIT_BURST` (bucket capacity). Defaults keep the limiter disabled.
 

--- a/sheetbridge/logging.py
+++ b/sheetbridge/logging.py
@@ -9,7 +9,7 @@ from typing import Callable
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import PlainTextResponse, Response
 
 SENSITIVE_HEADERS = {"authorization"}
 
@@ -42,9 +42,11 @@ class AccessLogMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
             status = response.status_code
             return response
-        except Exception as exc:  # pragma: no cover - pass through after logging
+        except Exception as exc:  # pragma: no cover - handled after logging
             error = repr(exc)
-            raise
+            response = PlainTextResponse("Internal Server Error", status_code=500)
+            status = response.status_code
+            return response
         finally:
             duration_ms = int((time.time() - start) * 1000)
             record = {

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from sheetbridge.logging import AccessLogMiddleware
+
+
+def test_request_id_header_on_error() -> None:
+    app = FastAPI()
+    app.add_middleware(AccessLogMiddleware)
+
+    @app.get("/boom")
+    def _boom() -> None:
+        raise RuntimeError("boom")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/boom")
+
+    assert response.status_code == 500
+    assert response.headers["X-Request-ID"]


### PR DESCRIPTION
## Summary
- ensure the access logging middleware returns a fallback 500 response that carries the X-Request-ID header when a route raises
- document the guaranteed header propagation for server errors in README and HANDOFF
- add a regression test that asserts the request ID header is present on error responses

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d698d91cbc83308b850cfad29c736a