### PR TITLE
Restrict dev token fallback to explicit configuration

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -29,7 +29,7 @@ Implementation notes:
 - Prometheus metrics include `sb_requests_total{method,path,status}`, `sb_request_latency_seconds{method,path}`, and `sb_errors_total{path}`. `/metrics` returns the standard text exposition format.
 - Token bucket rate limiting is disabled by default; enable by toggling `RATE_LIMIT_ENABLED` and tuning `RATE_LIMIT_RPS` + `RATE_LIMIT_BURST`. Buckets are keyed by client IP.
 - Future enhancement: persist upstream Sheet update timestamps or per-row hashes to make `since` filtering reflect actual Sheet edits rather than cache time.
-- `require_auth` now guards `/admin/*`, allowing the legacy bearer token (`Authorization: Bearer dev_token` unless `API_TOKEN` is overridden) or any key from the comma-separated `API_KEYS` list via the `X-API-Key` header.
+- `require_auth` now guards `/admin/*`, allowing the legacy bearer token (`Authorization: Bearer <API_TOKEN>`; defaults to `dev_token` unless you override the value) or any key from the comma-separated `API_KEYS` list via the `X-API-Key` header.
 
 Env:
 - Python 3.11 virtualenv (`python -m venv .venv && source .venv/bin/activate`)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Open http://127.0.0.1:8000/docs
 - Run the authenticated `POST /admin/idempotency/purge` maintenance endpoint to delete expired entries immediately. The endpoint responds with `{"purged": <count>}` indicating how many records were removed. All `/admin/*` routes require either a legacy bearer token or a configured API key.
 
 ### Authentication
-- Bearer tokens (legacy, `Authorization: Bearer dev_token`)
+- Bearer tokens (legacy, `Authorization: Bearer <API_TOKEN>`). The default token is `dev_token`; overriding `API_TOKEN` disables the dev token fallback unless you explicitly list `dev_token` in `API_KEYS`.
 - API keys: set `API_KEYS` env var (comma-separated). Use header `X-API-Key: <key>`.
 
 ### CORS

--- a/sheetbridge/auth.py
+++ b/sheetbridge/auth.py
@@ -14,8 +14,8 @@ def require_auth(
     authorization: str | None = Header(default=None),
     x_api_key: str | None = Header(default=None, alias="X-API-Key"),
 ):
-    valid_tokens = {settings.API_TOKEN, "dev_token"}
-    valid_tokens = {token for token in valid_tokens if token}
+    configured_token = (settings.API_TOKEN or "").strip()
+    valid_tokens = {configured_token} if configured_token else set()
     valid_keys = {k.strip() for k in settings.API_KEYS.split(",") if k.strip()}
     if authorization and authorization.startswith("Bearer "):
         token = authorization.split(" ", 1)[1].strip()


### PR DESCRIPTION
## Summary
- ensure the shared auth helper only accepts the configured API token or explicitly listed API keys instead of always whitelisting `dev_token`
- document the tightened bearer-token behavior in README and HANDOFF

## Testing
- pytest -q *(fails: missing optional dependency `httpx` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e906f9948330afc6e7a116af1c54